### PR TITLE
ci: point both jobs at repobuddy/.github, pinned to @v2

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,4 +6,10 @@ on:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify-linux.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-verify.yml@v2
+    with:
+      # unional/.github's pnpm-verify-linux.yml was linux-only. repobuddy's
+      # pnpm-verify.yml defaults to 3 OS x 2 Node, so pin ubuntu to keep the
+      # same matrix rather than silently tripling CI for a jest watch plugin.
+      os: '["ubuntu-latest"]'
+      skip-playwright: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,13 @@ on:
 
 jobs:
   code:
-    uses: unional/.github/.github/workflows/pnpm-verify-linux.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-verify.yml@v2
+    with:
+      os: '["ubuntu-latest"]'
+      skip-playwright: true
 
   release:
-    uses: unional/.github/.github/workflows/pnpm-release-changeset-oidc.yml@main
+    uses: repobuddy/.github/.github/workflows/pnpm-release-changeset-oidc.yml@v2
     needs: code
     permissions:
       id-token: write


### PR DESCRIPTION
Transferred into `repobuddy` on 2026-09-02, but both jobs still called `unional/.github` at a floating `@main` ref — a personal namespace and an unpinned branch.

## This one is not a like-for-like swap

`unional/.github`'s `pnpm-verify-linux.yml` has **no repobuddy counterpart, by design**. repobuddy has `pnpm-verify.yml`, whose default matrix is **3 OS × 2 Node = 6 jobs** where the old workflow was linux-only.

Left unpinned that would have quietly tripled CI for a jest watch plugin with no platform-specific behaviour. So:

- `os: '["ubuntu-latest"]'` — preserves the matrix the repo actually had
- `skip-playwright: true` — no browser tests here

**Job id preserved.** Still `code`, so the required `code / all-checks` context still exists.

## Related

This repo's npm trusted publisher was re-registered against `repobuddy/jest-watch-suspend` on 2026-09-03, resolving the org mismatch that had `main` at 1.1.3 while the registry sat at 1.1.2. That registration names the **caller** workflow `release.yml`, which this PR does not rename — so the pairing stays valid.

The banked 1.1.3 should publish on the next release run after this merges. Verify by reading `https://registry.npmjs.org/jest-watch-suspend` directly for 1.1.3 **and** a `dist.attestations` block — not with `npm view`, which serves a stale cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETjy9oQGyETyFmDBdR9Egz