### PR TITLE
fix: point repository metadata at repobuddy/jest-watch-suspend

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,12 @@ Run code coverage after running some `test.only()` tests:
 
 - `[s]` (suspend) ➣ change `test.only()` back to `test()` & `[e]` (with `jest-watch-toggle-config`) ➣ `[s]` (resume)
 
-[codecov-image]: https://codecov.io/gh/unional/jest-watch-suspend/branch/main/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/unional/jest-watch-suspend
+[codecov-image]: https://codecov.io/gh/repobuddy/jest-watch-suspend/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/repobuddy/jest-watch-suspend
 [downloads-image]: https://img.shields.io/npm/dm/jest-watch-suspend.svg?style=flat
 [downloads-url]: https://npmjs.org/package/jest-watch-suspend
-[github-action-image]: https://github.com/unional/jest-watch-suspend/workflows/release/badge.svg
-[github-action-url]: https://github.com/unional/jest-watch-suspend/actions
+[github-action-image]: https://github.com/repobuddy/jest-watch-suspend/workflows/release/badge.svg
+[github-action-url]: https://github.com/repobuddy/jest-watch-suspend/actions
 [npm-image]: https://img.shields.io/npm/v/jest-watch-suspend.svg?style=flat
 [npm-url]: https://npmjs.org/package/jest-watch-suspend
 [vscode-image]: https://img.shields.io/badge/vscode-ready-green.svg

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
 		"testing",
 		"tooling"
 	],
-	"homepage": "https://github.com/unional/jest-watch-suspend",
+	"homepage": "https://github.com/repobuddy/jest-watch-suspend",
 	"bugs": {
-		"url": "https://github.com/unional/jest-watch-suspend/issues"
+		"url": "https://github.com/repobuddy/jest-watch-suspend/issues"
 	},
 	"repository": {
 		"type": "git",
-		"url": "https://github.com/unional/jest-watch-suspend.git"
+		"url": "https://github.com/repobuddy/jest-watch-suspend.git"
 	},
 	"license": "MIT",
 	"author": {


### PR DESCRIPTION
The 2026-09-02 org transfer moved this repo but left `package.json` naming its old owner. **npm verifies the provenance bundle against `repository.url` at publish time**, so the next release fails with:

```
E422 Unprocessable Entity - PUT https://registry.npmjs.org/<pkg>
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "https://github.com/<old-owner>/<repo>.git",
expected to match "https://github.com/<new-owner>/<repo>" from provenance
```

## How this was found

`jest-watch-suspend`'s first post-transfer release run hit it. Its trusted publisher had already been re-registered correctly, so the error moved on from `E404` (wrong publisher) to `E422` (wrong metadata) — **a second fault hiding behind the first**. An audit then found every one of the 14 transferred repos carries the same stale URL.

Nothing warns you: the old GitHub path keeps resolving through the rename/transfer redirect, so the value looks valid right up until a publish verifies it against the OIDC claim.

## Scope

`package.json` metadata (`repository`, `bugs`, `homepage`) plus README links pointing at this repo's own old path.

**`CHANGELOG.md` is deliberately untouched** — those are historical release records and their commit/compare links still resolve through the redirect. Rewriting them would be noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETjy9oQGyETyFmDBdR9Egz